### PR TITLE
Enable SQL Server support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-DATABASE_URL="postgresql://user:password@localhost:5432/databuff"
+DATABASE_URL="sqlserver://localhost:1433;database=databuff;user=youruser;password=yourpassword;encrypt=true"
 JWT_SECRET="replace-with-strong-secret"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Databuff Skeleton
 
-This repository contains a minimal backend skeleton for the Databuff project described in the design document. The server is built with Node.js, TypeScript and Express. Prisma is used as ORM for a PostgreSQL database.
+This repository contains a minimal backend skeleton for the Databuff project described in the design document. The server is built with Node.js, TypeScript and Express. Prisma is used as ORM for a SQL Server database.
 
 ## Development
 
@@ -10,7 +10,7 @@ This repository contains a minimal backend skeleton for the Databuff project des
 npm install
 ```
 
-2. Configure the database connection by creating a `.env` file with a `DATABASE_URL` variable pointing to your PostgreSQL instance.
+2. Configure the database connection by creating a `.env` file with a `DATABASE_URL` variable pointing to your SQL Server instance.
 
 3. Generate Prisma client (requires internet access to fetch engines):
 
@@ -41,7 +41,7 @@ Copy `.env.example` to `.env` and update the variables for your environment.
 cp .env.example .env
 ```
 
-Update `DATABASE_URL` to point to your PostgreSQL instance and set a strong `JWT_SECRET`.
+Update `DATABASE_URL` to point to your SQL Server instance and set a strong `JWT_SECRET`.
 
 ## API Usage
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,12 +1,12 @@
 // Prisma schema for Databuff
-// Database: PostgreSQL
+// Database: SQL Server
 
 generator client {
   provider = "prisma-client-js"
 }
 
 datasource db {
-  provider = "postgresql"
+  provider = "sqlserver"
   url      = env("DATABASE_URL")
 }
 
@@ -36,7 +36,7 @@ model User {
   email              String   @unique
   points             Int      @default(0)
   status             String   @default("active")
-  roles              String[] @default(["requester", "worker"])
+  roles              String   @default("[\"requester\",\"worker\"]") // JSON encoded roles
   reputation_score   Decimal  @default(0)
   accuracy_score     Decimal  @default(0)
   completed_task_count Int    @default(0)
@@ -144,5 +144,5 @@ model Message {
 
   @@index([conversation_id, sent_at(sort: Desc)], name: "idx_message_conversation_sent_at")
   @@index([sender_user_id], name: "idx_message_sender")
-  @@index([content], type: Gin, name: "message")
+  @@index([content], name: "idx_message_content")
 }


### PR DESCRIPTION
## Summary
- switch Prisma provider to sqlserver
- store user roles as JSON string
- update example environment and docs for SQL Server
- adjust index to be cross-database

## Testing
- `npm install`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma format` *(fails: 403 Forbidden)*
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma validate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685ac1645a20832e9492abae7cffa45c